### PR TITLE
Feat: output additional SARIF data

### DIFF
--- a/src/lib/formatters/get-sarif-result.ts
+++ b/src/lib/formatters/get-sarif-result.ts
@@ -30,6 +30,16 @@ export function getResults(testResult): sarif.Result[] {
           },
         },
       ],
+      fixes: vuln.isUpgradable
+        ? [
+            {
+              description: {
+                text: `Upgrade ${vuln.packageName} to version ${vuln.fixedIn}`,
+              },
+              artifactChanges: [],
+            },
+          ]
+        : undefined,
     }),
   );
 }

--- a/src/lib/formatters/get-sarif-result.ts
+++ b/src/lib/formatters/get-sarif-result.ts
@@ -28,6 +28,11 @@ export function getResults(testResult): sarif.Result[] {
               startLine: vuln.lineNumber || 1,
             },
           },
+          logicalLocations: [
+            {
+              fullyQualifiedName: `${vuln.packageName}@${vuln.version}`,
+            }
+          ]
         },
       ],
       fixes: vuln.isUpgradable

--- a/src/lib/formatters/get-sarif-result.ts
+++ b/src/lib/formatters/get-sarif-result.ts
@@ -10,6 +10,7 @@ export function getResults(testResult): sarif.Result[] {
     groupedVulnerabilities,
     ([vuln]): sarif.Result => ({
       ruleId: vuln.id,
+      rank: (vuln as CvssScore).cvssScore,
       level: getLevel(vuln),
       message: {
         text: `This file introduces a vulnerable ${vuln.packageName} package with a ${vuln.severity} severity vulnerability.`,
@@ -31,6 +32,10 @@ export function getResults(testResult): sarif.Result[] {
       ],
     }),
   );
+}
+
+interface CvssScore {
+  cvssScore: number;
 }
 
 export function getLevel(vuln: AnnotatedIssue) {

--- a/src/lib/formatters/open-source-sarif-output.ts
+++ b/src/lib/formatters/open-source-sarif-output.ts
@@ -28,6 +28,9 @@ export function createSarifOutputForOpenSource(
       tool: {
         driver: {
           name: 'Snyk Open Source',
+          properties: {
+            artifactsScanned: testResult.dependencyCount
+          },
           rules: getRules(testResult),
         },
       },

--- a/test/jest/unit/lib/formatters/__snapshots__/open-source-sarif-output.spec.ts.snap
+++ b/test/jest/unit/lib/formatters/__snapshots__/open-source-sarif-output.spec.ts.snap
@@ -7,6 +7,14 @@ Object {
     Object {
       "results": Array [
         Object {
+          "fixes": Array [
+            Object {
+              "artifactChanges": Array [],
+              "description": Object {
+                "text": "Upgrade ajv to version 6.12.3",
+              },
+            },
+          ],
           "level": "error",
           "locations": Array [
             Object {

--- a/test/jest/unit/lib/formatters/__snapshots__/open-source-sarif-output.spec.ts.snap
+++ b/test/jest/unit/lib/formatters/__snapshots__/open-source-sarif-output.spec.ts.snap
@@ -23,12 +23,16 @@ Object {
           "message": Object {
             "text": "This file introduces a vulnerable ajv package with a critical severity vulnerability.",
           },
+          "rank": 7.5,
           "ruleId": "SNYK-JS-AJV-584908",
         },
       ],
       "tool": Object {
         "driver": Object {
           "name": "Snyk Open Source",
+          "properties": Object {
+            "artifactsScanned": 969,
+          },
           "rules": Array [
             Object {
               "fullDescription": Object {

--- a/test/jest/unit/lib/formatters/__snapshots__/open-source-sarif-output.spec.ts.snap
+++ b/test/jest/unit/lib/formatters/__snapshots__/open-source-sarif-output.spec.ts.snap
@@ -18,6 +18,11 @@ Object {
           "level": "error",
           "locations": Array [
             Object {
+              "logicalLocations": Array [
+                Object {
+                  "fullyQualifiedName": "ajv@6.12.2",
+                },
+              ],
               "physicalLocation": Object {
                 "artifactLocation": Object {
                   "uri": "package.json",

--- a/test/jest/unit/lib/formatters/open-source-sarif-output.spec.ts
+++ b/test/jest/unit/lib/formatters/open-source-sarif-output.spec.ts
@@ -3,7 +3,12 @@ import { SEVERITY, TestResult } from '../../../../../src/lib/snyk-test/legacy';
 
 describe('createSarifOutputForOpenSource', () => {
   it('general', () => {
-    const testFile = getTestResult();
+    const testFile = getTestResult(
+      {}, // testResultOverride
+      {
+        cvssScore: 7.5 // vulnOverride
+      }
+    );
     const sarif = createSarifOutputForOpenSource([testFile]);
     expect(sarif).toMatchSnapshot();
   });


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Adds the following data to open source SARIF output:
* Number of artifacts scanned
* CVSS score
* Fix information
* Package info in pURL format

#### Where should the reviewer start?
Please take a look at the thread referenced below for additional info.

#### How should this be manually tested?
* Build the CLI
* Run a command similar to `./binary-releases/snyk-macos test --file=/Users/schottsfired/Desktop/vulnerable/pom.xml --sarif-file-output=/Users/schottsfired/Desktop/test-output.sarif`

#### Any background context you want to provide?
See thread [here](https://snyk.slack.com/archives/C1NREQSG0/p1694113046308119) for additional information on why these fields were added.

#### What are the relevant tickets?


#### Screenshots


#### Additional questions
* I noticed that the `vuln` object includes a `cvssScore` in the SARIF output, but I couldn't find a type/declaration for `cvssScore`, so I casted `vuln` to a custom `CvssScore` type to extract the `cvssScore` value from the `vuln` object. I'm more of a Java developer than TS, so please forgive my ignorance and let me know if there's a better way.